### PR TITLE
feat(ci): add scaffold for preview environment workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,5 +16,9 @@ permissions:
 jobs:
   laravel-tests:
     uses: ./.github/workflows/reusable-ci.yaml
+    if: |
+      (
+      !contains(github.event.pull_request.labels.*.name, vars.DEPLOY_PREVIEW_LABEL)
+      )
     secrets:
       APP_KEY_CI: ${{ secrets.APP_KEY_CI }}

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -59,6 +59,7 @@ jobs:
       )
       && (
         github.event.action == 'closed'
+        || (github.event.action == 'unlabeled' && github.event.label.name == vars.DEPLOY_PREVIEW_LABEL)
       )
     environment:
       name: Preview

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -1,0 +1,68 @@
+name: Ephemeral Preview Environment
+
+on:
+  pull_request:
+    types: [ opened, synchronize, reopened, closed, labeled, unlabeled ]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  laravel-tests-preview:
+    uses: ./.github/workflows/reusable-ci.yaml
+    if: |
+      (
+        contains(vars.ALLOWED_AUTHOR_ASSOCIATIONS, github.event.pull_request.author_association)
+      )
+      && (
+        contains(github.event.pull_request.labels.*.name, vars.DEPLOY_PREVIEW_LABEL)
+      )
+      && (
+        github.event.pull_request.head.repo.full_name == github.repository
+      )
+      && (
+        github.event.action != 'closed'
+      )
+    secrets:
+      APP_KEY_CI: ${{ secrets.APP_KEY_CI }}
+
+  build_image:
+    runs-on: ubuntu-latest
+    needs: [ laravel-tests-preview ]
+    steps:
+      - name: Run build image
+        run: |
+          echo "✅ build image successfully created!"
+
+  deploy_preview:
+    runs-on: ubuntu-latest
+    needs: [ laravel-tests-preview, build_image ]
+    environment:
+      name: Preview
+    steps:
+      - name: Run deploy environment preview
+        run: |
+          echo "✅ deploy environment preview successfully created!"
+
+  destroy_preview:
+    runs-on: ubuntu-latest
+    if: |
+      (
+        contains(vars.ALLOWED_AUTHOR_ASSOCIATIONS, github.event.pull_request.author_association)
+      )
+      && (
+        github.event.pull_request.head.repo.full_name == github.repository
+      )
+      && (
+        github.event.action == 'closed'
+      )
+    environment:
+      name: Preview
+    steps:
+      - name: Run destroy environment preview
+        run: |
+          echo "✅ destroy environment preview successfully created!"

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  laravel-tests-preview:
+  laravel-tests:
     uses: ./.github/workflows/reusable-ci.yaml
     if: |
       (
@@ -32,7 +32,7 @@ jobs:
 
   build_image:
     runs-on: ubuntu-latest
-    needs: [ laravel-tests-preview ]
+    needs: [ laravel-tests ]
     steps:
       - name: Run build image
         run: |
@@ -40,7 +40,7 @@ jobs:
 
   deploy_preview:
     runs-on: ubuntu-latest
-    needs: [ laravel-tests-preview, build_image ]
+    needs: [ laravel-tests, build_image ]
     environment:
       name: Preview
     steps:


### PR DESCRIPTION
#### Summary

This PR introduces the initial structure (scaffold) for a new GitHub Actions workflow to automatically create and destroy **ephemeral preview environments** for Pull Requests.

#### What was done?

* A new workflow file has been created at `.github/workflows/preview.yaml`.
* The workflow is triggered by PR events, such as adding a specific label (`vars.DEPLOY_PREVIEW_LABEL`) and closing the PR.
* The necessary jobs have been defined: test, build, deploy, and destroy.
* **Important:** In this initial phase, the `build`, `deploy`, and `destroy` steps are just **placeholders** that run `echo` commands for debugging purposes. **No real deployment is performed.**

#### Purpose of this PR

The main goal is to validate the trigger logic and execution conditions in a real-world scenario. By applying and removing the deploy label on this PR, we can observe in the "Actions" tab whether the workflow behaves as expected before we implement the final deployment logic.

#### How to Test and Verify

1.  Review the workflow code at `.github/workflows/preview.yaml`.
2.  Add the label defined in the `DEPLOY_PREVIEW_LABEL` variable to this PR.
3.  Check the "Actions" tab to see if the workflow is triggered and if the simulation jobs (`echo`) run in the correct order.
4.  (Optional) Remove the label or close/reopen the PR to see how the workflow reacts to different events.

#### Next Steps

After this PR is approved and merged, the next step will be to replace the `echo` commands with the actual logic for building the image and deploying to our cloud provider.