### PR TITLE
feat(ci): implement v1 of the preview environment workflow

### DIFF
--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -71,8 +71,8 @@ jobs:
             br.com.carlosalexandre.preview.pr.${{ vars.PROJECT_NAME }}=${{ env.PR_NUMBER }}
             br.com.carlosalexandre.preview.general-${{ vars.PROJECT_NAME }}=true
           build-args: |
-            COMPOSER_CACHE_KEY=${{ hashFiles('composer.lock') }}
-            NPM_CACHE_KEY=${{ hashFiles('package-lock.json') }}
+            COMPOSER_CACHE_VERSION=${{ hashFiles('composer.lock') }}
+            NPM_CACHE_VERSION=${{ hashFiles('package-lock.json') }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -137,9 +137,22 @@ jobs:
     environment:
       name: Preview
     steps:
-      - name: Run destroy environment preview
-        run: |
-          echo "✅ preview environment destroyed successfully!"
+      - name: Destroy Environment on VPS
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.VPS_HOST }}
+          username: ${{ secrets.VPS_USER }}
+          key: ${{ secrets.VPS_SSH_KEY }}
+          script: |
+            export PR_NUMBER=${{ env.PR_NUMBER }}
+            export PROJECT_NAME=${{ vars.PROJECT_NAME }}
+            export PROJECT_DIR=/var/www/$PROJECT_NAME/previews/pr-${{ env.PR_NUMBER }}
+            
+            if [ -d "$PROJECT_DIR" ]; then
+              cat $PROJECT_DIR/deploy/preview/destroy-preview.sh | bash -s
+            else
+              echo "Project directory not found. Nothing to do."
+            fi
 
       - name: Install and Login to regctl
         run: |

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -81,10 +81,45 @@ jobs:
     needs: [ laravel-tests, build_image ]
     environment:
       name: Preview
+    permissions:
+      pull-requests: write
     steps:
-      - name: Run deploy environment preview
-        run: |
-          echo "✅ preview environment deployed successfully!"
+      - name: Deploy to VPS
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.VPS_HOST }}
+          username: ${{ secrets.VPS_USER }}
+          key: ${{ secrets.VPS_SSH_KEY }}
+          script: |
+            export PR_NUMBER=${{ env.PR_NUMBER }}
+            export PROJECT_NAME=${{ vars.PROJECT_NAME }}
+            export IMAGE_TAG=pr-${{ env.PR_NUMBER }}
+            export REPO_FULL_NAME=${{ github.repository }}
+            export COMMIT_SHA=${{ github.event.pull_request.head.sha }}
+            export PROJECT_DIR=/var/www/$PROJECT_NAME/previews/pr-${{ env.PR_NUMBER }}
+            
+            if [ ! -d "$PROJECT_DIR" ]; then
+              echo "Cloning repository for the first time at ${PROJECT_DIR}..."
+              git clone "git@github.com:${REPO_FULL_NAME}.git" "${PROJECT_DIR}"
+            fi
+            
+            cd "${PROJECT_DIR}"
+            
+            git fetch origin
+            git checkout "${COMMIT_SHA}"
+            
+            bash $PROJECT_DIR/deploy/preview/deploy-preview.sh
+
+      - name: Post Preview URL to PR
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          number: ${{ env.PR_NUMBER }}
+          header: preview-url
+          message: |
+            ✅ **Preview ready!**
+            Access it at: https://${{ vars.PROJECT_NAME }}-pr-${{ env.PR_NUMBER }}.preview.carlosalexandre.com.br
+
+            > Image: `${{ github.repository }}:pr-${{ env.PR_NUMBER }}`
 
   destroy_preview:
     runs-on: ubuntu-latest

--- a/deploy/preview/deploy-preview.sh
+++ b/deploy/preview/deploy-preview.sh
@@ -1,0 +1,1 @@
+echo "✅ preview environment deployed successfully!"

--- a/deploy/preview/destroy-preview.sh
+++ b/deploy/preview/destroy-preview.sh
@@ -1,0 +1,1 @@
+echo "✅ preview environment destroyed successfully!"


### PR DESCRIPTION
#### Summary

This PR introduces the first full version of our **ephemeral preview environment** system. The goal is to automate the creation and destruction of a temporary, live online environment for each pull request, allowing changes to be tested and reviewed in a real-world scenario before merging.

#### How it Works

The process is initiated when a developer adds the `DEPLOY_PREVIEW_LABEL` to a pull request. This triggers the `preview.yaml` workflow, which performs the following steps:

1.  **Runs Tests:** Ensures the code passes the full test suite. The main CI workflow (`ci.yaml`) is instructed to skip its run to avoid duplication.
2.  **Builds Docker Image:** A PR-specific Docker image is built, tagged (e.g., `pr-123`), and pushed to Docker Hub.
3.  **Deploys to Server:** The workflow connects to a server via SSH, clones the repository, and checks out the PR's exact commit. It then executes a deployment script.
4.  **Posts URL to PR:** A sticky comment is posted to the pull request with a link to access the preview environment.
5.  **Automatic Cleanup:** When the PR is closed or the label is removed, the workflow performs a two-stage cleanup:
    * **Server-Side:** It connects to the server via SSH to run a cleanup script, tearing down the environment (e.g., stopping containers).
    * **Registry-Side:** It deletes the PR-specific image tag from Docker Hub to keep our registry clean.

#### How to Test and Verify

1.  **Add** the `DEPLOY_PREVIEW_LABEL` to this PR.
2.  Wait for the workflow to complete in the "Actions" tab.
3.  Verify that a **comment with the preview URL** has appeared below.
4.  (Optional) Go to **Docker Hub** and confirm that the image with the tag `pr-<this_pr_number>` was created.
5.  **Remove** the label from the PR.
6.  Check the "Actions" tab and verify that the `destroy_preview` job ran successfully, including the steps for **server-side cleanup** and **image tag removal**.

#### Next Steps

Currently, the scripts executed on the server (`deploy/preview/deploy-preview.sh` and `deploy/preview/destroy-preview.sh`) are placeholders. The next step will be to implement the actual logic within them (e.g., `docker compose up` and `docker compose down`) to manage the services in the preview environment.